### PR TITLE
Make panes draggable for resizing

### DIFF
--- a/src/panes/ComponentPane.jsx
+++ b/src/panes/ComponentPane.jsx
@@ -21,7 +21,7 @@ export default function ComponentPane ({ style, state, onStateChange, onClose })
 
   const paneChoice = state && state.type && menuOptions[state.type] ? state.type : 'test'
   const InnerComponent = menuOptions[paneChoice]?.Component
-  const innerStyle = { position: 'absolute', left: 0, top: 0, bottom: 0, right: 0, overflowY: 'auto' }
+  const innerStyle = { position: 'absolute', left: 0, top: 0, bottom: 0, right: 0, overflowX: 'hidden', overflowY: 'hidden' }
 
   return (
     <Box

--- a/src/panes/SplitPane.jsx
+++ b/src/panes/SplitPane.jsx
@@ -3,28 +3,102 @@ import Divider from '@mui/material/Divider'
 
 import ComponentPane from './ComponentPane'
 import { Stack } from '@mui/material'
+import { useRef } from 'react'
 
-function SplitDivider ({ direction }) {
+function SplitDivider ({ direction, ...rest }) {
   return (
     <Box sx={{ position: 'relative', flexGrow: 0 }}>
       <Divider orientation={direction === 'row' ? 'vertical' : 'horizontal'} />
+      <Box
+        sx={{
+          background: (theme) => theme.palette.primary.main,
+          position: 'absolute',
+          inset: (theme) => `-${theme.spacing(0.5)}`,
+          zIndex: (theme) => theme.zIndex.fab,
+          opacity: 0,
+          transition: (theme) => theme.transitions.create(['opacity'], {
+            duration: theme.transitions.duration.shorter
+          }),
+          '&:hover': {
+            opacity: 1
+          },
+          cursor: direction === 'row' ? 'e-resize' : 'n-resize'
+        }}
+        {...rest}
+      />
     </Box>
   )
 }
 
-function Split ({ split, direction, style, children }) {
-  split = typeof (split) === 'undefined' ? 0.5 : split
+function Split ({ split, direction, onChange, style, children }) {
+  split = typeof(split) === 'undefined' ? 0.5 : split
+  const root = useRef()
+  const pane1 = useRef()
+  const pane2 = useRef()
+
+  // If user starts dragging a split, resize the divide between children accordingly
+  const startDragging = dragStartEvent => {
+    dragStartEvent.target.setPointerCapture(dragStartEvent.pointerId)
+    let previousDragPos = null
+    const handleMouseMove = e => {
+      if(direction === 'row') {
+        if (previousDragPos !== null) {
+          split += (e.clientX - previousDragPos) / root.current.offsetWidth
+        }
+        previousDragPos = e.clientX
+      } else {
+        if (previousDragPos !== null) {
+          split += (e.clientY - previousDragPos) / root.current.offsetHeight
+        }
+        previousDragPos = e.clientY
+      }
+      // constrain split to [0,1]
+      split = Math.min(Math.max(0, split), 1)
+      pane1.current.style.flexGrow = split
+      pane2.current.style.flexGrow = 1 - split
+      e.preventDefault()
+      e.stopPropagation()
+    }
+    document.addEventListener('mousemove', handleMouseMove)
+
+    const handleMouseDown = e => {
+      e.preventDefault()
+      e.stopPropagation()
+    }
+    document.addEventListener('mousedown', handleMouseDown)
+
+    const handleMouseUp = e => {
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mousedown', handleMouseDown)
+      document.removeEventListener('mouseup', handleMouseUp)
+      e.preventDefault()
+      e.stopPropagation()
+      dragStartEvent.target.releasePointerCapture(dragStartEvent.pointerId)
+      if (onChange) {
+        onChange(split)
+      }
+    }
+    document.addEventListener('mouseup', handleMouseUp)
+  }
 
   return (
     <Stack
+      ref={root}
       direction={direction}
       style={style}
     >
-      <Box style={{ flexGrow: split, position: 'relative' }}>
+      <Box
+        ref={pane1} 
+        style={{ flexGrow: split, position: 'relative' }}>
         {children[0]}
       </Box>
-      <SplitDivider direction={direction} />
-      <Box style={{ flexGrow: split, position: 'relative' }}>
+      <SplitDivider 
+        direction={direction} 
+        onPointerDown={startDragging}
+      />
+      <Box 
+        ref={pane2}
+        style={{ flexGrow: 1 - split, position: 'relative' }}>
         {children[1]}
       </Box>
     </Stack>
@@ -36,7 +110,9 @@ export default function SplitPane ({ state, onStateChange, direction, style }) {
 
   return (
     <Split
+      split={state?.split}
       direction={direction}
+      onChange={split => {onStateChange({...state, split})}}
       style={style}
     >
       <ComponentPane


### PR DESCRIPTION
Hovering over the divider between panes reveals a box that can be clicked and dragged to change the relative sizes of the panes on either side of the divider. Any overflowing content within panes will be hidden, so it is important that any component rendered within a ComponentPane accounts for variable heights and widths. 