### PR TITLE
Dynamic, resizable camera components

### DIFF
--- a/src/panes/CameraPane.jsx
+++ b/src/panes/CameraPane.jsx
@@ -46,21 +46,17 @@ export default function CameraPane () {
       }}
     >
       <img
-        style={{ ...imageStyle, maxHeight: '100%', maxWidth: '100%' }}
+        style={{ ...imageStyle, objectFit: 'contain' }}
         alt='Video Feed.'
         src={cameras[currentCamera].url}
         onContextMenu={handleClick}
       />
       <Menu
-        id='basic-menu'
         anchorPosition={anchorPosition}
         anchorReference='anchorPosition'
         open={open}
         onClose={handleClose}
         onChange={(e) => { setCurrentCamera(e.target.value) }}
-        MenuListProps={{
-          'aria-labelledby': 'basic-button'
-        }}
       >
         {cameras.map((camera, index) => (<MenuItem key={`${camera.name}-${index}`} onClick={() => { setCurrentCamera(index); setAnchorPosition(null) }}>{camera.name}</MenuItem>))}
       </Menu>

--- a/src/panes/CameraPane.jsx
+++ b/src/panes/CameraPane.jsx
@@ -1,0 +1,68 @@
+import { useRef, useState } from 'react'
+import Box from '@mui/material/Box'
+import MenuItem from '@mui/material/MenuItem'
+import TextField from '@mui/material/TextField'
+
+export default function CameraPane () {
+  // TODO: replace with context provider and hooks model
+  const cameras = [
+    { name: 'Chassis Cam', url: 'https://images.unsplash.com/photo-1580757468214-c73f7062a5cb?q=80&w=1000&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8MTYlM0E5fGVufDB8fDB8fHww', ratio: 1000 / 563 },
+    { name: 'Mast Cam', url: 'http://192.168.1.202:8081/', ratio: 16 / 9 },
+    { name: 'Arm Cam', url: 'http://192.168.1.203:8081/', ratio: 16 / 9 }]
+  const [currentCamera, setCurrentCamera] = useState(0)
+  const containerRef = useRef(null)
+
+  const calculateImageDimensions = () => {
+    if (!containerRef.current) { return { height: '100%', width: 'auto' } }
+    if (containerRef.current.offsetWidth / containerRef.current.offsetHeight < cameras[currentCamera].ratio) {
+      // Container is narrower than the image
+      return { width: '100%', height: 'auto' }
+    } else {
+      // Container is wider than the image
+      return { height: '100%', width: 'auto' }
+    }
+  }
+
+  const imageStyle = calculateImageDimensions()
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        maxHeight: '100%',
+        maxWidth: '100%',
+        overflow: 'hidden',
+        paddingTop: 2
+      }}
+    >
+      {/* Move this into a context menu */}
+      {/* <TextField
+        value={currentCamera}
+        label='Camera Select'
+        select
+        onChange={(e) => { setCurrentCamera(e.target.value) }}
+      >
+        {cameras.map((camera, index) => (<MenuItem value={index} key={camera.name}>{camera.name}</MenuItem>))}
+      </TextField> */}
+
+      <Box
+        ref={containerRef}
+        sx={{
+          // ...imageStyle,
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center'
+        }}
+      >
+        <img
+          style={{ ...imageStyle, maxHeight: '100%', maxWidth: '100%' }}
+          alt='Video Feed.'
+          src={cameras[currentCamera].url}
+        />
+      </Box>
+    </Box>
+  )
+}

--- a/src/panes/CameraPane.jsx
+++ b/src/panes/CameraPane.jsx
@@ -7,12 +7,12 @@ export default function CameraPane () {
   // TODO: replace with context provider and hooks model
   const cameras = [
     { name: 'Chassis Cam', url: 'https://images.unsplash.com/photo-1580757468214-c73f7062a5cb?q=80&w=1000&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8MTYlM0E5fGVufDB8fDB8fHww', ratio: 1000 / 563 },
-    { name: 'Mast Cam', url: 'https://www.sjsurobotics.org/assets/img/gallery/current-team.jpeg', ratio: 2798/1573 },
+    { name: 'Mast Cam', url: 'https://www.sjsurobotics.org/assets/img/gallery/current-team.jpeg', ratio: 2798 / 1573 },
     { name: 'Arm Cam', url: 'http://192.168.1.203:8081/', ratio: 16 / 9 }]
   const [currentCamera, setCurrentCamera] = useState(0)
   const containerRef = useRef(null)
 
-  const [anchorPosition, setAnchorPosition] = useState(null);
+  const [anchorPosition, setAnchorPosition] = useState(null)
   const open = Boolean(anchorPosition)
   const handleClick = (e) => {
     e.preventDefault()
@@ -35,35 +35,35 @@ export default function CameraPane () {
 
   const imageStyle = calculateImageDimensions()
   return (
-      <Box
-        ref={containerRef}
-        sx={{
-          height: '100%',
-          width: '100%',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center'
+    <Box
+      ref={containerRef}
+      sx={{
+        height: '100%',
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center'
+      }}
+    >
+      <img
+        style={{ ...imageStyle, maxHeight: '100%', maxWidth: '100%' }}
+        alt='Video Feed.'
+        src={cameras[currentCamera].url}
+        onContextMenu={handleClick}
+      />
+      <Menu
+        id='basic-menu'
+        anchorPosition={anchorPosition}
+        anchorReference='anchorPosition'
+        open={open}
+        onClose={handleClose}
+        onChange={(e) => { setCurrentCamera(e.target.value) }}
+        MenuListProps={{
+          'aria-labelledby': 'basic-button'
         }}
       >
-        <img
-          style={{ ...imageStyle, maxHeight: '100%', maxWidth: '100%' }}
-          alt='Video Feed.'
-          src={cameras[currentCamera].url}
-          onContextMenu={handleClick}
-        />
-        <Menu
-          id="basic-menu"
-          anchorPosition={anchorPosition}
-          anchorReference='anchorPosition'
-          open={open}
-          onClose={handleClose}
-          onChange={(e) => { setCurrentCamera(e.target.value) }}
-          MenuListProps={{
-            'aria-labelledby': 'basic-button',
-          }}
-        >
-          {cameras.map((camera, index) => (<MenuItem key={`${camera.name}-${index}`} onClick={() => {setCurrentCamera(index); setAnchorPosition(null)}}>{camera.name}</MenuItem>))}
-        </Menu>
-      </Box>
+        {cameras.map((camera, index) => (<MenuItem key={`${camera.name}-${index}`} onClick={() => { setCurrentCamera(index); setAnchorPosition(null) }}>{camera.name}</MenuItem>))}
+      </Menu>
+    </Box>
   )
 }

--- a/src/panes/CameraPane.jsx
+++ b/src/panes/CameraPane.jsx
@@ -1,16 +1,26 @@
 import { useRef, useState } from 'react'
 import Box from '@mui/material/Box'
+import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
-import TextField from '@mui/material/TextField'
 
 export default function CameraPane () {
   // TODO: replace with context provider and hooks model
   const cameras = [
     { name: 'Chassis Cam', url: 'https://images.unsplash.com/photo-1580757468214-c73f7062a5cb?q=80&w=1000&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8MTYlM0E5fGVufDB8fDB8fHww', ratio: 1000 / 563 },
-    { name: 'Mast Cam', url: 'http://192.168.1.202:8081/', ratio: 16 / 9 },
+    { name: 'Mast Cam', url: 'https://www.sjsurobotics.org/assets/img/gallery/current-team.jpeg', ratio: 2798/1573 },
     { name: 'Arm Cam', url: 'http://192.168.1.203:8081/', ratio: 16 / 9 }]
   const [currentCamera, setCurrentCamera] = useState(0)
   const containerRef = useRef(null)
+
+  const [anchorPosition, setAnchorPosition] = useState(null);
+  const open = Boolean(anchorPosition)
+  const handleClick = (e) => {
+    e.preventDefault()
+    setAnchorPosition({ left: e.clientX, top: e.clientY })
+  }
+  const handleClose = () => {
+    setAnchorPosition(null)
+  }
 
   const calculateImageDimensions = () => {
     if (!containerRef.current) { return { height: '100%', width: 'auto' } }
@@ -25,31 +35,9 @@ export default function CameraPane () {
 
   const imageStyle = calculateImageDimensions()
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        maxHeight: '100%',
-        maxWidth: '100%',
-        overflow: 'hidden',
-        paddingTop: 2
-      }}
-    >
-      {/* Move this into a context menu */}
-      {/* <TextField
-        value={currentCamera}
-        label='Camera Select'
-        select
-        onChange={(e) => { setCurrentCamera(e.target.value) }}
-      >
-        {cameras.map((camera, index) => (<MenuItem value={index} key={camera.name}>{camera.name}</MenuItem>))}
-      </TextField> */}
-
       <Box
         ref={containerRef}
         sx={{
-          // ...imageStyle,
           height: '100%',
           width: '100%',
           display: 'flex',
@@ -61,8 +49,21 @@ export default function CameraPane () {
           style={{ ...imageStyle, maxHeight: '100%', maxWidth: '100%' }}
           alt='Video Feed.'
           src={cameras[currentCamera].url}
+          onContextMenu={handleClick}
         />
+        <Menu
+          id="basic-menu"
+          anchorPosition={anchorPosition}
+          anchorReference='anchorPosition'
+          open={open}
+          onClose={handleClose}
+          onChange={(e) => { setCurrentCamera(e.target.value) }}
+          MenuListProps={{
+            'aria-labelledby': 'basic-button',
+          }}
+        >
+          {cameras.map((camera, index) => (<MenuItem key={`${camera.name}-${index}`} onClick={() => {setCurrentCamera(index); setAnchorPosition(null)}}>{camera.name}</MenuItem>))}
+        </Menu>
       </Box>
-    </Box>
   )
 }

--- a/src/panes/SplitPane.jsx
+++ b/src/panes/SplitPane.jsx
@@ -31,7 +31,7 @@ function SplitDivider ({ direction, ...rest }) {
 }
 
 function Split ({ split, direction, onChange, style, children }) {
-  split = typeof(split) === 'undefined' ? 0.5 : split
+  split = typeof (split) === 'undefined' ? 0.5 : split
   const root = useRef()
   const pane1 = useRef()
   const pane2 = useRef()
@@ -41,7 +41,7 @@ function Split ({ split, direction, onChange, style, children }) {
     dragStartEvent.target.setPointerCapture(dragStartEvent.pointerId)
     let previousDragPos = null
     const handleMouseMove = e => {
-      if(direction === 'row') {
+      if (direction === 'row') {
         if (previousDragPos !== null) {
           split += (e.clientX - previousDragPos) / root.current.offsetWidth
         }
@@ -88,17 +88,19 @@ function Split ({ split, direction, onChange, style, children }) {
       style={style}
     >
       <Box
-        ref={pane1} 
-        style={{ flexGrow: split, position: 'relative' }}>
+        ref={pane1}
+        style={{ flexGrow: split, position: 'relative' }}
+      >
         {children[0]}
       </Box>
-      <SplitDivider 
-        direction={direction} 
+      <SplitDivider
+        direction={direction}
         onPointerDown={startDragging}
       />
-      <Box 
+      <Box
         ref={pane2}
-        style={{ flexGrow: 1 - split, position: 'relative' }}>
+        style={{ flexGrow: 1 - split, position: 'relative' }}
+      >
         {children[1]}
       </Box>
     </Stack>
@@ -112,7 +114,7 @@ export default function SplitPane ({ state, onStateChange, direction, style }) {
     <Split
       split={state?.split}
       direction={direction}
-      onChange={split => {onStateChange({...state, split})}}
+      onChange={split => { onStateChange({ ...state, split }) }}
       style={style}
     >
       <ComponentPane

--- a/src/panes/index.jsx
+++ b/src/panes/index.jsx
@@ -1,7 +1,9 @@
+import CameraPane from './CameraPane'
 import TestComponent from './TestComponent'
 import SplitPane from './SplitPane'
 
 const panes = {
+  camera: { title: 'Camera', Component: CameraPane },
   test: { title: 'Test', Component: TestComponent },
   vSplit: { title: 'Split Vertically', Component: (props) => (<SplitPane {...props} direction='row' />) },
   hSplit: { title: 'Split Horizontally', Component: (props) => (<SplitPane {...props} />) }


### PR DESCRIPTION
Cameras currently use statically or publicly hosted images, but we will pass in urls and ratios for the actual rover cameras in the future. They can be resized by dragging the boundaries of the component, and they will respond to either a constrained height or width appropriately. Right clicking opens up a context menu to switch between images.

Big shoutout to @NathanaelG2099 for getting this started here: https://github.com/NathanaelG2099/psychic-adventure